### PR TITLE
Modern (1.10) django changes

### DIFF
--- a/socketio/sdjango.py
+++ b/socketio/sdjango.py
@@ -1,10 +1,9 @@
 import logging
 
+from django.conf.urls import url
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.utils.importlib import import_module
-
-from django.conf.urls import patterns
+from importlib import import_module
 
 logger = logging.getLogger("socketio")
 
@@ -55,6 +54,9 @@ def socketio(request):
 
     return HttpResponse("")
 
+
 autodiscover()
 
-urls = patterns("", (r'', socketio))
+urlpatterns = [
+    url('', socketio)
+]


### PR DESCRIPTION
Support django 1.10 by removing python 2.6 support. Refactored sdjango.py to act as a urls.py module.